### PR TITLE
Do not remove empty <a> tags that could be used as anchors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 /htmllaundry.egg-info
 /build
 /dist
+/bin
+/include/
+/lib
+/pip-selfcheck.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.pyo
 *.egg
+/.eggs
 /htmllaundry.egg-info
 /build
 /dist

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.1 - Unreleased
 -------------------------
 
-* ...
+* Do not remove empty ``<a>`` tags that could be used as anchors.
 
 
 2.0 - December 2012, 2012

--- a/htmllaundry/tests.py
+++ b/htmllaundry/tests.py
@@ -93,6 +93,17 @@ class remove_empty_tags_tests(unittest.TestCase):
                 self._remove(six.u('<div><br/>Test</div>')),
                 six.u('<div>Test</div>'))
 
+    def testDoNotRemoveEmptyAnchorElement(self):
+        self.assertEqual(
+                self._remove(six.u('<p><a id="anchor"></a></p>')),
+                six.u('<p><a id="anchor"/></p>'))
+        self.assertEqual(
+                self._remove(six.u('<p><a name="anchor" /></p>')),
+                six.u('<p><a name="anchor"/></p>'))
+        self.assertEqual(
+                self._remove(six.u('<p><a href="blah"/>Content</p>')),
+                six.u('<p>Content</p>'))
+
 
 class ForceLinkTargetTests(unittest.TestCase):
     def force_link_target(self, str, target='_blank'):

--- a/htmllaundry/tests.py
+++ b/htmllaundry/tests.py
@@ -94,6 +94,7 @@ class remove_empty_tags_tests(unittest.TestCase):
                 six.u('<div>Test</div>'))
 
     def testDoNotRemoveEmptyAnchorElement(self):
+        # Should not remove empty <a> tag because it's used as an anchor:
         self.assertEqual(
                 self._remove(six.u('<p><a id="anchor"></a></p>')),
                 six.u('<p><a id="anchor"/></p>'))
@@ -101,7 +102,29 @@ class remove_empty_tags_tests(unittest.TestCase):
                 self._remove(six.u('<p><a name="anchor" /></p>')),
                 six.u('<p><a name="anchor"/></p>'))
         self.assertEqual(
+                self._remove(six.u('<p><a href="blah" id="anchor"/></p>')),
+                six.u('<p><a href="blah" id="anchor"/></p>'))
+        self.assertEqual(
+                self._remove(six.u('<p><a href="blah" name="anchor"/></p>')),
+                six.u('<p><a href="blah" name="anchor"/></p>'))
+
+        # Should not remove <a> tag because it's non-empty:
+        self.assertEqual(
+                self._remove(six.u('<p><a href="blah" name="anchor">Link</a></p>')),
+                six.u('<p><a href="blah" name="anchor">Link</a></p>'))
+        self.assertEqual(
+                self._remove(six.u('<p><a name="anchor">Link</a></p>')),
+                six.u('<p><a name="anchor">Link</a></p>'))
+        self.assertEqual(
+                self._remove(six.u('<p><a href="anchor">Link</a></p>')),
+                six.u('<p><a href="anchor">Link</a></p>'))
+
+        # Should remove because it's an useless empty tag.
+        self.assertEqual(
                 self._remove(six.u('<p><a href="blah"/>Content</p>')),
+                six.u('<p>Content</p>'))
+        self.assertEqual(
+                self._remove(six.u('<p><a href="blah"></a>Content</p>')),
                 six.u('<p>Content</p>'))
 
 

--- a/htmllaundry/utils.py
+++ b/htmllaundry/utils.py
@@ -77,6 +77,10 @@ def remove_empty_tags(doc):
             if el.tag in legal_empty_tags:
                 continue
 
+            # Empty <a> can be used as anchor.
+            if (el.tag == 'a') and (('name' in el.attrib) or ('id' in el.attrib)):
+                continue
+
             if len(el) == 0 and is_whitespace(el.text):
                 victims.append(el)
                 continue


### PR DESCRIPTION
Added a test. All tests are passing.

Example of empty <a> that should not be removed:

```
<a href="anchor">Link to other section</a>
Some text.
<a name="anchor" />
<h2>Other section</h2>
Some other text.
```
