### PR TITLE
For remove_empty_tags, allow additional legal empty tags to be passed in

### DIFF
--- a/htmllaundry/tests.py
+++ b/htmllaundry/tests.py
@@ -36,11 +36,11 @@ class strip_markup_tests(unittest.TestCase):
 
 
 class remove_empty_tags_tests(unittest.TestCase):
-    def _remove(self, str):
+    def _remove(self, str, extra_tags=[]):
         from htmllaundry.utils import remove_empty_tags
         import lxml.etree
         fragment = lxml.etree.fromstring(str)
-        fragment = remove_empty_tags(fragment)
+        fragment = remove_empty_tags(fragment, extra_tags)
         return lxml.etree.tostring(fragment, encoding=six.text_type)
 
     def testRemoveEmptyParagraphElement(self):
@@ -92,6 +92,15 @@ class remove_empty_tags_tests(unittest.TestCase):
         self.assertEqual(
                 self._remove(six.u('<div><br/>Test</div>')),
                 six.u('<div>Test</div>'))
+
+    def testExtraAllowedEmptyTags(self):
+        self.assertEqual(
+            self._remove(
+                six.u('<table><tr><td>Test</td><td></td></tr></table>'),
+                ['td']
+            ),
+            six.u('<table><tr><td>Test</td><td/></tr></table>')
+        )
 
 
 class ForceLinkTargetTests(unittest.TestCase):

--- a/htmllaundry/utils.py
+++ b/htmllaundry/utils.py
@@ -44,7 +44,7 @@ def remove_element(el):
     parent.remove(el)
 
 
-def remove_empty_tags(doc):
+def remove_empty_tags(doc, extra_empty_tags=[]):
     """Removes all empty tags from a HTML document. Javascript editors
     and browsers have a nasty habit of leaving stray tags around after
     their contents have been removed. This function removes all such
@@ -54,8 +54,9 @@ def remove_empty_tags(doc):
     This forces whitespace styling to be done using CSS instead of via an
     editor, which almost always produces better and more consistent results.
     """
-
-    legal_empty_tags = frozenset(['br', 'hr', 'img', 'input'])
+    empty_tags = set(['br', 'hr', 'img', 'input'])
+    empty_tags.update(set(extra_empty_tags))
+    legal_empty_tags = frozenset(empty_tags)
 
     if hasattr(doc, 'getroot'):
         doc = doc.getroot()


### PR DESCRIPTION
Use-case: In a  `<table>`, we might not want to strip away empty cells, but preserve the table structure.